### PR TITLE
Include string.h to use strchr

### DIFF
--- a/XString.xs
+++ b/XString.xs
@@ -13,6 +13,7 @@
 #include <perl.h>
 #include <XSUB.h>
 #include <embed.h>
+#include <string.h>
 
 /* stolen from B::cstring */
 static SV *


### PR DESCRIPTION
Fix #4

strchr is coming from string.h
we should import it to make sure it's available.